### PR TITLE
Add support for Ubuntu 14.04 (Trusty)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ansible-hdfs
 
-An Ansible role for installing [CDH HDFS](http://www.cloudera.com/content/cloudera/en/products-and-services/cdh.html).
+An Ansible role for installing [Cloudera HDFS](http://www.cloudera.com/content/cloudera/en/products-and-services/cdh.html).
 
 ## Role Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-hdfs_version: "2.5.0+cdh5.2.0+551-1.cdh5.2.0.p0.46~precise-cdh5.2.0"
+hdfs_version: "2.5.0+cdh5.2.0+551-1.cdh5.2.0.p0.46~trusty-cdh5.2.0"
 hdfs_conf_dir: "/etc/hadoop/conf"
 hdfs_namenode: False
 hdfs_namenode_host: localhost

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -15,7 +15,9 @@ if [ "up", "provision" ].include?(ARGV.first) &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/precise64"
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.network "forwarded_port", guest: 50070, host: 50070
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,8 +8,9 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+    - trusty
     - precise
   categories:
   - system
 dependencies:
-  - { role: "azavea.java", java_version: "7u71-2.5.3-0ubuntu0.12.04.1" }
+  - { role: "azavea.java", java_version: "7u71-2.5.3-0ubuntu0.14.04.1" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,5 +7,8 @@
   apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-cdh5 contrib"
                   state=present
 
+- name: Pin Cloudera APT repositories
+  template: src=cdh5.j2 dest=/etc/apt/preferences.d/cdh5
+
 - { include: namenode.yml, when: hdfs_namenode }
 - { include: datanode.yml, when: not hdfs_namenode }

--- a/templates/cdh5.j2
+++ b/templates/cdh5.j2
@@ -1,0 +1,7 @@
+Package: *
+Pin: release n={{ ansible_distribution_release }}
+Pin-Priority: 100
+
+Package: *
+Pin: release n={{ ansible_distribution_release }}-cdh5
+Pin-Priority: 600


### PR DESCRIPTION
In addition, this changeset gives the Cloudera repository priority over the default Ubuntu repositories for cases where package names match and we want the Cloudera packages to win.
