### PR TITLE
Avoid mounting devices that are already mounted

### DIFF
--- a/tasks/datanode.yml
+++ b/tasks/datanode.yml
@@ -16,9 +16,8 @@
 
 - name: Create Hadoop HDFS DataNode data directories
   file: path={{ item.mount_point }}
-        owner=hdfs
-        group=hdfs
         state=directory
+  register: existing_data_directory
   with_items: hdfs_disks
 
 - name: Check if device already has a file system
@@ -38,6 +37,7 @@
          src={{ item.device }}
          fstype=ext3
          state=mounted
+  when: existing_data_directory | changed
   with_items: hdfs_disks
 
 - name: Ensure Hadoop HDFS DataNode data directory permissions


### PR DESCRIPTION
To accommodate environments like EC2 where volumes can be automatically mounted via things like `cloud-config`, this changeset makes it so that Ansible only attempts to mount devices associated with a mount point if the mount point directory does not already exist.
