### PR TITLE
Add support for dynamic HDFS properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ An Ansible role for installing [Cloudera HDFS](http://www.cloudera.com/content/c
 - `hdfs_namenode_host` - Hostname of the HDFS NameNode (default: `localhost`)
 - `hdfs_namenode_port` - Port of the HDFS NameNode (default: `8020`)
 - `hdfs_disks` - A list of disks available on the HDFS DataNodes (default: `[]`)
+- `hdfs_core_properties` - A list of properties for the `core-site.xml` configuration file.
+- `hdfs_namenode_host` - A list of properties for the NameNode `hdfs-site.xml` configuration file.
+- `hdfs_datanode_properties` - A list of properties for the DataNode `hdfs-site.xml` configuration file.
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,12 @@ hdfs_namenode: False
 hdfs_namenode_host: localhost
 hdfs_namenode_port: 8020
 hdfs_disks: []
+
+hdfs_core_properties:
+  - { name: "fs.defaultFS", value: "hdfs://{{ hdfs_namenode_host }}:{{ hdfs_namenode_port }}" }
+hdfs_namenode_properties:
+  - { name: "dfs.permissions.superusergroup", value: "hadoop" }
+  - { name: "dfs.namenode.name.dir", value: "/media/persistent0" }
+hdfs_datanode_properties:
+  - { name: "dfs.permissions.superusergroup", value: "hadoop" }
+  - { name: "dfs.datanode.data.dir", value: "{{ hdfs_disks | map(attribute='mount_point') | join(',') }}" }

--- a/templates/core-site.xml.j2
+++ b/templates/core-site.xml.j2
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
+{% for property in hdfs_core_properties -%}
   <property>
-    <name>fs.defaultFS</name>
-    <value>hdfs://{{ hdfs_namenode_host }}:{{ hdfs_namenode_port }}</value>
+    <name>{{ property.name }}</name>
+    <value>{{ property.value }}</value>
   </property>
+{% endfor -%}
 </configuration>

--- a/templates/datanode-hdfs-site.xml.j2
+++ b/templates/datanode-hdfs-site.xml.j2
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
+{% for property in hdfs_datanode_properties -%}
   <property>
-    <name>dfs.permissions.superusergroup</name>
-    <value>hadoop</value>
+    <name>{{ property.name }}</name>
+    <value>{{ property.value }}</value>
   </property>
-  <property>
-    <name>dfs.datanode.data.dir</name>
-    <value>{{ hdfs_disks | map(attribute="mount_point") | join(",") }}</value>
- </property>
+{% endfor -%}
 </configuration>

--- a/templates/namenode-hdfs-site.xml.j2
+++ b/templates/namenode-hdfs-site.xml.j2
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
+{% for property in hdfs_namenode_properties -%}
   <property>
-    <name>dfs.permissions.superusergroup</name>
-    <value>hadoop</value>
+    <name>{{ property.name }}</name>
+    <value>{{ property.value }}</value>
   </property>
-  <property>
- 	<name>dfs.namenode.name.dir</name>
- 	<value>/media/persistent0</value>
- </property>
+{% endfor -%}
 </configuration>


### PR DESCRIPTION
This changeset allows users to supply a list of properties for the `core-site.xml` and `hdfs-site.xml` configuration files for HDFS.