### PR TITLE
Feature/update hdfs role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Ansible role for installing [Cloudera HDFS](http://www.cloudera.com/content/c
 
 ## Role Variables
 
-- `hdfs_version` - HDFS version.
+- `hdfs_version` - HDFS version (default: `"2.5.0+cdh5.3.*"`)
 - `hdfs_conf_dir` - Configuration directory for HDFS (default: `/etc/hadoop/conf`)
 - `hdfs_namenode` - Flag to determine if a node is an HDFS NameNode (default: `False`)
 - `hdfs_namenode_host` - Hostname of the HDFS NameNode (default: `localhost`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-hdfs_version: "2.5.0+cdh5.2.0+551-1.cdh5.2.0.p0.46~trusty-cdh5.2.0"
+hdfs_version: "2.5.0+cdh5.3.*"
 hdfs_conf_dir: "/etc/hadoop/conf"
 hdfs_namenode: False
 hdfs_namenode_host: localhost

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,1 @@
-azavea.java,0.1.0
+azavea.java,0.2.1

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing CDH Hadoop.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.2
+  min_ansible_version: 1.8
   platforms:
   - name: Ubuntu
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,4 @@ galaxy_info:
   categories:
   - system
 dependencies:
-  - { role: "azavea.java", java_version: "7u71-2.5.3-0ubuntu0.14.04.1" }
+  - { role: "azavea.java" }


### PR DESCRIPTION
This fixes two issues I ran into yesterday when running the hdfs role.
  1. Default HDFS version not being available any longer
  2. Being unable to override the java version because it is set explicitly in dependencies

Also updates to use the latest Azavea java role