### PR TITLE
Bump HDFS version to 2.6; add variable for Cloudera distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An Ansible role for installing [Cloudera HDFS](http://www.cloudera.com/content/c
 
 ## Role Variables
 
-- `hdfs_version` - HDFS version (default: `"2.5.0+cdh5.3.*"`)
+- `hdfs_version` - HDFS version
+- `hdfs_cloudera_distribution` - Cloudera distribution version (default: `cdh5.4`)
 - `hdfs_conf_dir` - Configuration directory for HDFS (default: `/etc/hadoop/conf`)
 - `hdfs_namenode` - Flag to determine if a node is an HDFS NameNode (default: `False`)
 - `hdfs_namenode_host` - Hostname of the HDFS NameNode (default: `localhost`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-hdfs_version: "2.5.0+cdh5.3.*"
+hdfs_version: "2.6.0+cdh5.4.*"
+hdfs_cloudera_distribution: "cdh5.4"
 hdfs_conf_dir: "/etc/hadoop/conf"
 hdfs_namenode: False
 hdfs_namenode_host: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
            state=present
 
 - name: Configure the Cloudera APT repositories
-  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-cdh5 contrib"
+  apt_repository: repo="deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/{{ ansible_distribution_release }}/amd64/cdh {{ ansible_distribution_release }}-{{ hdfs_cloudera_distribution }} contrib"
                   state=present
 
 - name: Pin Cloudera APT repositories


### PR DESCRIPTION
This changeset bumps the default HDFS version to 2.6 and adds a `spark_cloudera_distribution` variable that is used to determine which Cloudera package distribution channel to use.

In addition, setting `hdfs_cloudera_distribution` to `cdh5` will automatically pull in major Cloudera repository changes (`cdh5.3` -> `cdh5.4`).
